### PR TITLE
migration file to use longtext instead of text for email_log table

### DIFF
--- a/src/database/migrations/2018_05_11_115355_use_longtext_for_attachments.php
+++ b/src/database/migrations/2018_05_11_115355_use_longtext_for_attachments.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
 
 class UseLongtextForAttachments extends Migration {
 
@@ -10,7 +11,9 @@ class UseLongtextForAttachments extends Migration {
 	 * @return void
 	 */
 	public function up() {
-		DB::statement('ALTER TABLE email_log MODIFY COLUMN attachments LONGTEXT');
+		Schema::table('email_log', function (Blueprint $table) {
+			$table->longText('attachments')->nullable()->change();
+		});
 	}
 
 	/**
@@ -19,7 +22,9 @@ class UseLongtextForAttachments extends Migration {
 	 * @return void
 	 */
 	public function down() {
-		DB::statement('ALTER TABLE email_log MODIFY COLUMN attachments TEXT');
+		Schema::table('email_log', function (Blueprint $table) {
+			$table->text('attachments')->nullable()->change();
+		});
 	}
 
 }

--- a/src/database/migrations/2018_05_11_115355_use_longtext_for_attachments.php
+++ b/src/database/migrations/2018_05_11_115355_use_longtext_for_attachments.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+class UseLongtextForAttachments extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up() {
+		DB::statement('ALTER TABLE email_log MODIFY COLUMN attachments LONGTEXT');
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down() {
+		DB::statement('ALTER TABLE email_log MODIFY COLUMN attachments TEXT');
+	}
+
+}


### PR DESCRIPTION
I send a few mails with attached pdf documents. 
Unfortunately they can not get saved and are not sent. 
The reason is that the MySQL TEXT data type can store only 64kB of data. 
MEDIUMTEXT can save 16MB and LONGTEXT can store up to 4GB. 
So I simply changed the datatype of attachments from TEXT to LONGTEXT. 
