### PR TITLE
update for laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "illuminate/support": "~5.0|~6.0",
+        "illuminate/support": "~5.0|~6.0|~7.0",
         "doctrine/dbal": "*"
     },
     "autoload": {


### PR DESCRIPTION
Laravel 7 is official released.
Updating `composer.json` to support Laravel 7.