### PR TITLE
change: truncate values of long string fields to database field length

### DIFF
--- a/src/ShvetsGroup/LaravelEmailDatabaseLog/EmailLogger.php
+++ b/src/ShvetsGroup/LaravelEmailDatabaseLog/EmailLogger.php
@@ -22,7 +22,7 @@ class EmailLogger
             'to' => $this->formatAddressField($message, 'To'),
             'cc' => $this->formatAddressField($message, 'Cc'),
             'bcc' => $this->formatAddressField($message, 'Bcc'),
-            'subject' => $message->getSubject(),
+            'subject' => substr($message->getSubject(), 0, 255),
             'body' => $message->getBody(),
             'headers' => (string)$message->getHeaders(),
             'attachments' => $message->getChildren() ? implode("\n\n", $message->getChildren()) : null,
@@ -54,6 +54,6 @@ class EmailLogger
             }
             $strings[] = $mailboxStr;
         }
-        return implode(', ', $strings);
+        return substr(implode(', ', $strings), 0, 255);
     }
 }

--- a/src/ShvetsGroup/LaravelEmailDatabaseLog/EmailLogger.php
+++ b/src/ShvetsGroup/LaravelEmailDatabaseLog/EmailLogger.php
@@ -26,6 +26,7 @@ class EmailLogger
             'body' => $message->getBody(),
             'headers' => (string)$message->getHeaders(),
             'attachments' => $message->getChildren() ? implode("\n\n", $message->getChildren()) : null,
+            'message_id' => substr($this->getMessageId($message), 0, 255)
         ]);
     }
 
@@ -55,5 +56,10 @@ class EmailLogger
             $strings[] = $mailboxStr;
         }
         return substr(implode(', ', $strings), 0, 255);
+    }
+
+    function getMessageId($message) {
+        $header = $message->getHeaders()->get('Message-ID');
+        return $header ? $header->getId() : null;
     }
 }

--- a/src/database/migrations/2021_04_04_120015_add_message_id_email_log.php
+++ b/src/database/migrations/2021_04_04_120015_add_message_id_email_log.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddMessageIdEmailLog extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('email_log', function (Blueprint $table) {
+            $table->string('message_id')->nullable();
+            $table->index(['message_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('email_log', function (Blueprint $table) {
+            $table->dropColumn('message_id');
+        });
+    }
+}

--- a/src/database/migrations/2021_07_12_120000_change_body_longtext.php
+++ b/src/database/migrations/2021_07_12_120000_change_body_longtext.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class ChangeBodyLongtext extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('email_log', function (Blueprint $table) {
+            $table->longtext('body')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('email_log', function (Blueprint $table) {
+            $table->dropColumn('message_id');
+        });
+    }
+}


### PR DESCRIPTION
in the email_log table, some fields (addresses and subject) have type
'string', which means laravel creates them with a default length of 255
characters.

however, in case of many e-mails - e.g. in cc - the total length of a
header can exceed this character limit. theoretically, a single e-mail
address could be [up to 320 characters long](https://stackoverflow.com/a/49645137/3096626)

before this patch, the length limit was not checked and e-mails would
not be logged. error message:

```
[previous exception] [object] (PDOException(code: 22001): SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'bcc' at row 1 at /var/www/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:115)
[stacktrace]
```

this patch truncates fields at 255 characters so the log entry can be
created. the untruncated contents are still available in the body
column.

test code:

```php
Mail::send([], [], function($message) {
    $message->to('test@longdomain.com.' . str_repeat('x', 255))->subject('Test')->setBody('E-Mail'); 
});
```