### PR TITLE
Add tests, Github Workflow and drop support for EOL Laravel Versions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,47 @@
+name: run-tests
+
+on:
+    push:
+        branches: [master]
+    pull_request:
+        branches: [master]
+
+jobs:
+    test:
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: true
+            matrix:
+                os: [ubuntu-latest, windows-latest]
+                php: [7.3, 7.4, 8.0]
+                laravel: [6.*, 8.*]
+                stability: [prefer-lowest, prefer-stable]
+                include:
+                    - laravel: 6.*
+                      testbench: ^4.14
+                    - laravel: 8.*
+                      testbench: ^6.20
+
+        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php }}
+                  extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+                  coverage: none
+
+            - name: Setup problem matchers
+              run: |
+                  echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+                  echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+            - name: Install dependencies
+              run: |
+                  composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+                  composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+            - name: Execute tests
+              run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.phar
 composer.lock
 .DS_Store
+.phpunit.result.cache

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,4 @@
+preset: laravel
+
+disabled:
+  - single_class_element_per_statement

--- a/README.md
+++ b/README.md
@@ -11,11 +11,6 @@ Laravel Email Database Log can be installed via [composer](http://getcomposer.or
 ```bash
 composer require shvetsgroup/laravel-email-database-log
 ```
-for publish migration files
-```bash
-php artisan vendor:publish --tag=laravel-email-database-log-migration
-php artisan migrate
-```
 
 ## Step 2: Configuration
 
@@ -30,8 +25,12 @@ You can skip this step if your version of Laravel is 5.5 or above. Otherwise, yo
 
 ## Step 3: Migration
 
-Now, run this in terminal:
+Publish migration files:
+```bash
+php artisan vendor:publish --tag=laravel-email-database-log-migration
+```
 
+Now, run this in terminal:
 ```bash
 php artisan migrate
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,22 +1,43 @@
 {
     "name": "shvetsgroup/laravel-email-database-log",
     "description": "A simple database logger for all outgoing emails sent by Laravel website.",
-    "keywords": ["laravel", "markdown"],
+    "keywords": ["laravel", "markdown", "mail"],
     "license": "MIT",
     "authors": [
         {
             "name": "Alexander Shvets",
             "email": "neochief@shvetsgroup.com"
+        },
+        {
+            "name": "Spaan Productions",
+            "email": "info@spaanproductions.nl",
+            "role": "Developer"
         }
     ],
     "require": {
-        "illuminate/support": "~5.0|~6.0|~7.0|~8.0",
+        "illuminate/support": "~6.0|~8.0",
         "doctrine/dbal": "^2.10"
+    },
+    "require-dev": {
+        "orchestra/testbench": "^4.0|^6.0",
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
         "psr-0": {
             "ShvetsGroup\\LaravelEmailDatabaseLog\\": "src/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "ShvetsGroup\\LaravelEmailDatabaseLog\\Tests\\": "tests"
+        }
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit",
+        "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
+    },
+    "config": {
+        "sort-packages": true
     },
     "extra": {
         "laravel": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        bootstrap="vendor/autoload.php"
+        backupGlobals="false"
+        backupStaticAttributes="false"
+        colors="true"
+        verbose="true"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        processIsolation="false"
+        stopOnFailure="false"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+>
+    <coverage>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </coverage>
+    <testsuites>
+        <!--<testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>-->
+        <testsuite name="Feature">
+            <directory suffix="Test.php">./tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <server name="APP_ENV" value="testing"/>
+        <server name="BCRYPT_ROUNDS" value="4"/>
+        <server name="CACHE_DRIVER" value="array"/>
+        <server name="DB_CONNECTION" value="sqlite"/>
+        <server name="DB_DATABASE" value=":memory:"/>
+        <server name="MAIL_DRIVER" value="array"/>
+        <server name="MAIL_MAILER" value="array"/>
+        <server name="QUEUE_CONNECTION" value="sync"/>
+        <server name="SESSION_DRIVER" value="array"/>
+    </php>
+</phpunit>

--- a/tests/Feature/LaravelEmailDatabaseTest.php
+++ b/tests/Feature/LaravelEmailDatabaseTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace ShvetsGroup\LaravelEmailDatabaseLog\Tests\Feature;
+
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use ShvetsGroup\LaravelEmailDatabaseLog\Tests\TestCase;
+use ShvetsGroup\LaravelEmailDatabaseLog\Tests\Mail\TestMail;
+
+class LaravelEmailDatabaseTest extends TestCase
+{
+	use RefreshDatabase;
+
+	/** @test */
+	public function the_email_is_logged_to_the_database()
+	{
+		Mail::to('email@example.com')
+			->send(new TestMail());
+
+		$this->assertDatabaseHas('email_log', [
+			'date' => now()->format('Y-m-d H:i:s'),
+			'from' => 'Example <hello@example.com>',
+			'to' => 'email@example.com',
+			'cc' => null,
+			'bcc' => null,
+			'subject' => 'The e-mail subject',
+			'body' => '<p>Some random string.</p>',
+			'attachments' => null,
+		]);
+	}
+}

--- a/tests/Mail/TestMail.php
+++ b/tests/Mail/TestMail.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ShvetsGroup\LaravelEmailDatabaseLog\Tests\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class TestMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this
+	        ->subject('The e-mail subject')
+	        ->html('<p>Some random string.</p>');
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace ShvetsGroup\LaravelEmailDatabaseLog\Tests;
+
+use ShvetsGroup\LaravelEmailDatabaseLog\LaravelEmailDatabaseLogServiceProvider;
+
+class TestCase extends \Orchestra\Testbench\TestCase
+{
+	public function getEnvironmentSetUp($app)
+	{
+		// import the migrations
+		include_once __DIR__ . '/../src/database/migrations/2015_07_31_1_email_log.php';
+		include_once __DIR__ . '/../src/database/migrations/2016_09_21_001638_add_bcc_column_email_log.php';
+		include_once __DIR__ . '/../src/database/migrations/2017_11_10_001638_add_more_mail_columns_email_log.php';
+		include_once __DIR__ . '/../src/database/migrations/2018_05_11_115355_use_longtext_for_attachments.php';
+
+		// run the up() method of those migration classes
+		(new \EmailLog)->up();
+		(new \AddBccColumnEmailLog)->up();
+		(new \AddMoreMailColumnsEmailLog)->up();
+		(new \UseLongtextForAttachments)->up();
+	}
+
+	protected function getPackageProviders($app)
+	{
+		return [
+			LaravelEmailDatabaseLogServiceProvider::class,
+		];
+	}
+}


### PR DESCRIPTION
This PR drops support for Laravel 5.x & 7.x because they are EOL. 
This should also be tagged as a major version because of the dropped support.

It also adds some tests to the packages so we can make sure the intended behavior is still the same.. 

