### PR TITLE
Laravel 9.x Support

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,14 +13,12 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                php: [7.3, 7.4, 8.0]
-                laravel: [6.*, 8.*]
+                php: [8.0, 8.1]
+                laravel: [9.*]
                 stability: [prefer-lowest, prefer-stable]
                 include:
-                    - laravel: 6.*
-                      testbench: ^4.14
-                    - laravel: 8.*
-                      testbench: ^6.20
+                    - laravel: 9.*
+                      testbench: ^7.0
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,13 @@
         }
     ],
     "require": {
-        "illuminate/support": "~6.0|~8.0",
-        "doctrine/dbal": "^2.10"
+        "php": "^8.0.2",
+        "illuminate/support": "^9.0",
+        "doctrine/dbal": "^3.3",
+        "nesbot/carbon": "^2.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.0|^6.0",
+        "orchestra/testbench": "^7.0",
         "phpunit/phpunit": "^9.0"
     },
     "autoload": {

--- a/src/ShvetsGroup/LaravelEmailDatabaseLog/LaravelEmailDatabaseLogServiceProvider.php
+++ b/src/ShvetsGroup/LaravelEmailDatabaseLog/LaravelEmailDatabaseLogServiceProvider.php
@@ -3,7 +3,6 @@
 namespace ShvetsGroup\LaravelEmailDatabaseLog;
 
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Mail\Events\MessageSending;
 
 class LaravelEmailDatabaseLogServiceProvider extends ServiceProvider
 {

--- a/tests/Feature/LaravelEmailDatabaseTest.php
+++ b/tests/Feature/LaravelEmailDatabaseTest.php
@@ -2,10 +2,13 @@
 
 namespace ShvetsGroup\LaravelEmailDatabaseLog\Tests\Feature;
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
+use Symfony\Component\Mime\Encoder\Base64Encoder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use ShvetsGroup\LaravelEmailDatabaseLog\Tests\TestCase;
 use ShvetsGroup\LaravelEmailDatabaseLog\Tests\Mail\TestMail;
+use ShvetsGroup\LaravelEmailDatabaseLog\Tests\Mail\TestMailWithAttachment;
 
 class LaravelEmailDatabaseTest extends TestCase
 {
@@ -27,5 +30,77 @@ class LaravelEmailDatabaseTest extends TestCase
 			'body' => '<p>Some random string.</p>',
 			'attachments' => null,
 		]);
+	}
+
+	/** @test */
+	public function multiple_recipients_are_comma_separated()
+	{
+		Mail::to(['email@example.com', 'email2@example.com'])
+			->send(new TestMail());
+
+		$this->assertDatabaseHas('email_log', [
+			'date' => now()->format('Y-m-d H:i:s'),
+			'to' => 'email@example.com, email2@example.com',
+			'cc' => null,
+			'bcc' => null,
+		]);
+	}
+
+	/** @test */
+	public function recipient_with_name_is_correctly_formatted()
+	{
+		Mail::to((object)['email' => 'email@example.com', 'name' => 'John Do'])
+			->send(new TestMail());
+
+		$this->assertDatabaseHas('email_log', [
+			'date' => now()->format('Y-m-d H:i:s'),
+			'to' => 'John Do <email@example.com>',
+			'cc' => null,
+			'bcc' => null,
+		]);
+	}
+
+	/** @test */
+	public function cc_recipient_with_name_is_correctly_formatted()
+	{
+		Mail::cc((object)['email' => 'email@example.com', 'name' => 'John Do'])
+			->send(new TestMail());
+
+		$this->assertDatabaseHas('email_log', [
+			'date' => now()->format('Y-m-d H:i:s'),
+			'to' => null,
+			'cc' => 'John Do <email@example.com>',
+			'bcc' => null,
+		]);
+	}
+
+	/** @test */
+	public function bcc_recipient_with_name_is_correctly_formatted()
+	{
+		Mail::bcc((object)['email' => 'email@example.com', 'name' => 'John Do'])
+			->send(new TestMail());
+
+		$this->assertDatabaseHas('email_log', [
+			'date' => now()->format('Y-m-d H:i:s'),
+			'to' => null,
+			'cc' => null,
+			'bcc' => 'John Do <email@example.com>',
+		]);
+	}
+
+	/** @test */
+	public function attachement_is_saved()
+	{
+		Mail::to('email@example.com')->send(new TestMailWithAttachment());
+
+		$log = DB::table('email_log')->first();
+
+		// TODO: Is there a beter way to tests this ?
+		$encoded = (new Base64Encoder)->encodeString(file_get_contents(__DIR__ . '/../stubs/demo.txt'));
+
+		$this->assertStringContainsString('Content-Type: text/plain; name=demo.txt', $log->attachments);
+		$this->assertStringContainsString('Content-Transfer-Encoding: base64', $log->attachments);
+		$this->assertStringContainsString('Content-Disposition: attachment; name=demo.txt; filename=demo.txt', $log->attachments);
+		$this->assertStringContainsString($encoded, $log->attachments);
 	}
 }

--- a/tests/Mail/TestMailWithAttachment.php
+++ b/tests/Mail/TestMailWithAttachment.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ShvetsGroup\LaravelEmailDatabaseLog\Tests\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class TestMailWithAttachment extends Mailable
+{
+	use Queueable, SerializesModels;
+
+	/**
+	 * Create a new message instance.
+	 *
+	 * @return void
+	 */
+	public function __construct()
+	{
+		//
+	}
+
+	/**
+	 * Build the message.
+	 *
+	 * @return $this
+	 */
+	public function build()
+	{
+		return $this
+			->subject('The e-mail subject')
+			->attach(__DIR__ . '/../stubs/demo.txt')
+			->html('<p>Some random string.</p>');
+	}
+}

--- a/tests/stubs/demo.txt
+++ b/tests/stubs/demo.txt
@@ -1,0 +1,1 @@
+This is a demo attachment.


### PR DESCRIPTION
This PR will drop all support for Laravel 8.x and below and **only support Laravel 9.x**.
Because Laravel 9.x **only supports PHP 8.x** and up we also drop support for any old PHP versions. 

Because Laravel switched form `SwiftMailer` to `Symfony Mailer` the implementation changed and any logged data could be saved differently, if this is the case please let me know. But i think alle should be the same. (I added some tests to have some better feedback for the future).